### PR TITLE
Add website events guide

### DIFF
--- a/docs/guides/website/add-events.md
+++ b/docs/guides/website/add-events.md
@@ -1,1 +1,35 @@
 # How To Add Events
+
+- This page provides a step-by-step walkthrough on how to add an event to the main [CCSS website](https://github.com/CarletonComputerScienceSociety/website).
+
+  - **Step 1: Create an event markdown file**
+
+    - Go to [content/events](https://github.com/CarletonComputerScienceSociety/website/tree/master/content/events) in the CCSS website GitHub
+    - Go inside the directory for the current academic year (i.e., 2025-2026)
+    - Add a new file named something like `2024-09-10-frosh-social.md`
+    - Include an example frontmatter and body content:
+
+      ```md
+      ---
+      title: "Frosh Social"
+      date: 2024-09-10
+      time: "6:00 PM"
+      location: "Canal Ritz"
+      preview: "images/event_posters/2024/frosh-social.jpg"
+      ---
+
+      Come meet your fellow first-years and have fun at our first social event of the year!
+      ```
+
+  - **Step 2: Add your event poster**
+
+    - Upload your image to [static/images/event_posters](https://github.com/CarletonComputerScienceSociety/website/tree/master/static/images/event_posters) in the CCSS website GitHub
+    - Recommended path/filename: `images/event_posters/2024/event-name.jpg`
+
+  - **Step 3: Commit your changes**
+
+    - Include both the markdown file and the image in your PR
+    - Example commit message:
+      `Add Frosh Social event for Sept 10`
+
+- If there are still any questions, please feel free to reach out to your fellow execs for assistance.


### PR DESCRIPTION
## ✅ Acceptance Criteria

* [x] A new page exists at `docs/guides/website/add-events.md`
* [x] The guide includes:

  * A clear explanation of where to add the event markdown file
  * An example frontmatter block and markdown body
  * Instructions for uploading the poster image
  * A sample commit message
* [x] All links point to the correct GitHub repo paths
* [x] The page is properly formatted and appears in the sidebar under "Guides > Website"